### PR TITLE
Fix some plug-in metadata and product launch config

### DIFF
--- a/server/org.eclipse.emfcloud.ecore.glsp-app/org.eclipse.emfcloud.ecore.glsp.feature/feature.xml
+++ b/server/org.eclipse.emfcloud.ecore.glsp-app/org.eclipse.emfcloud.ecore.glsp.feature/feature.xml
@@ -42,7 +42,6 @@
       <import plugin="org.eclipse.emf.edit" version="2.16.0" match="compatible"/>
       <import plugin="javax.inject"/>
       <import plugin="org.eclipse.equinox.app" version="1.4.0" match="greaterOrEqual"/>
-      <import plugin="org.eclipse.emfcloud.ecore.glsp" version="0.0.2" match="greaterOrEqual"/>
    </requires>
 
    <plugin

--- a/server/org.eclipse.emfcloud.ecore.modelserver-app/org.eclipse.emfcloud.ecore.modelserver.feature/feature.xml
+++ b/server/org.eclipse.emfcloud.ecore.modelserver-app/org.eclipse.emfcloud.ecore.modelserver.feature/feature.xml
@@ -28,21 +28,36 @@
          id="org.eclipse.core.runtime.feature"
          version="0.0.0"/>
 
+   <includes
+         id="org.eclipse.emfcloud.ecore.glsp.feature"
+         version="0.0.0"/>
+
+   <includes
+         id="org.eclipse.glsp.feature"
+         version="0.0.0"/>
+
+   <includes
+         id="org.eclipse.emfcloud.modelserver.feature"
+         version="0.0.0"/>
+
    <requires>
-      <import plugin="org.eclipse.equinox.app" version="1.4.0" match="greaterOrEqual"/>
-      <import plugin="org.eclipse.emfcloud.ecore.modelserver" version="0.0.2" match="greaterOrEqual"/>
       <import plugin="org.apache.log4j" version="1.2.15" match="compatible"/>
       <import plugin="org.apache.commons.io" version="2.6.0" match="compatible"/>
       <import plugin="com.google.inject" version="3.0.0" match="greaterOrEqual"/>
       <import plugin="com.google.guava"/>
       <import plugin="org.eclipse.emf.common"/>
       <import plugin="org.eclipse.emf.ecore.xmi"/>
-      <import plugin="org.eclipse.emfcloud.modelserver.client"/>
-      <import plugin="org.eclipse.emfcloud.modelserver.common"/>
-      <import plugin="org.eclipse.emfcloud.modelserver.edit" version="0.7.0" match="greaterOrEqual"/>
-      <import plugin="org.eclipse.emfcloud.modelserver.emf"/>
-      <import plugin="org.eclipse.emfcloud.modelserver.lib" version="0.7.0" match="greaterOrEqual"/>
       <import plugin="org.slf4j.api" version="1.7.30" match="greaterOrEqual"/>
+      <import plugin="org.eclipse.core.runtime" version="3.18.0" match="compatible"/>
+      <import plugin="org.eclipse.emf.ecore" version="2.22.0" match="compatible"/>
+      <import plugin="org.eclipse.elk.core" version="0.6.0" match="greaterOrEqual"/>
+      <import plugin="org.eclipse.elk.graph" version="0.6.0" match="greaterOrEqual"/>
+      <import plugin="org.eclipse.elk.alg.layered" version="0.6.0" match="greaterOrEqual"/>
+      <import plugin="org.eclipse.emf.ecore.change" version="2.14.0" match="compatible"/>
+      <import plugin="org.eclipse.emf.ecore.xmi" version="2.16.0" match="compatible"/>
+      <import plugin="org.eclipse.emf.edit" version="2.16.0" match="compatible"/>
+      <import plugin="javax.inject"/>
+      <import plugin="org.eclipse.equinox.app" version="1.4.0" match="greaterOrEqual"/>
    </requires>
 
    <plugin

--- a/server/org.eclipse.emfcloud.ecore.modelserver-app/org.eclipse.emfcloud.ecore.modelserver.product/org.eclipse.emfcloud.ecore.modelserver.product.launch
+++ b/server/org.eclipse.emfcloud.ecore.modelserver-app/org.eclipse.emfcloud.ecore.modelserver.product/org.eclipse.emfcloud.ecore.modelserver.product.launch
@@ -1,9 +1,17 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <launchConfiguration type="org.eclipse.pde.ui.RuntimeWorkbench">
-    <setAttribute key="additional_plugins"/>
+    <setAttribute key="additional_plugins">
+        <setEntry value="org.apache.felix.scr:2.1.16.v20200110-1820:default:true:2:true"/>
+        <setEntry value="org.eclipse.core.runtime:3.18.0.v20200506-2143:default:true:default:true"/>
+        <setEntry value="org.eclipse.equinox.common:3.12.0.v20200504-1602:default:true:2:true"/>
+        <setEntry value="org.eclipse.equinox.ds:1.6.200.v20200422-1833:default:true:2:true"/>
+        <setEntry value="org.eclipse.equinox.simpleconfigurator:1.3.500.v20200211-1505:default:true:1:true"/>
+        <setEntry value="org.eclipse.osgi:3.15.300.v20200520-1959:default:true:default:true"/>
+    </setAttribute>
     <booleanAttribute key="append.args" value="true"/>
+    <stringAttribute key="application" value="org.eclipse.emfcloud.ecore.modelserver.app.ecore-glsp-modelserver"/>
     <booleanAttribute key="askclear" value="true"/>
-    <booleanAttribute key="automaticAdd" value="true"/>
+    <booleanAttribute key="automaticAdd" value="false"/>
     <booleanAttribute key="automaticValidate" value="true"/>
     <stringAttribute key="bootstrap" value=""/>
     <stringAttribute key="checked" value="[NONE]"/>
@@ -11,79 +19,36 @@
     <booleanAttribute key="clearws" value="false"/>
     <booleanAttribute key="clearwslog" value="false"/>
     <stringAttribute key="configLocation" value="${workspace_loc}/.metadata/.plugins/org.eclipse.pde.core/org.eclipse.emfcloud.ecore.modelserver.product"/>
-    <booleanAttribute key="default" value="true"/>
+    <booleanAttribute key="default" value="false"/>
     <setAttribute key="deselected_workspace_bundles"/>
     <stringAttribute key="featureDefaultLocation" value="workspace"/>
     <stringAttribute key="featurePluginResolution" value="workspace"/>
     <booleanAttribute key="includeOptional" value="true"/>
     <stringAttribute key="location" value="${workspace_loc}/../runtime-org.eclipse.emfcloud.ecore.modelserver.product"/>
-    <booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
     <stringAttribute key="org.eclipse.jdt.launching.JRE_CONTAINER" value="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-11"/>
-    <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consoleLog"/>
+    <stringAttribute key="org.eclipse.jdt.launching.PROGRAM_ARGUMENTS" value="-os ${target.os} -ws ${target.ws} -arch ${target.arch} -nl ${target.nl} -consoleLog -nosplash"/>
     <stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.pde.ui.workbenchClasspathProvider"/>
     <stringAttribute key="pde.version" value="3.3"/>
     <stringAttribute key="product" value="org.eclipse.emfcloud.ecore.modelserver.app.product"/>
+    <stringAttribute key="productFile" value="/org.eclipse.emfcloud.ecore.modelserver.product/org.eclipse.emfcloud.ecore.modelserver.product"/>
     <setAttribute key="selected_features">
         <setEntry value="org.eclipse.core.runtime.feature:default"/>
-        <setEntry value="org.eclipse.emf.codegen.ecore:default"/>
-        <setEntry value="org.eclipse.emf.codegen:default"/>
-        <setEntry value="org.eclipse.emf.common:default"/>
-        <setEntry value="org.eclipse.emf.ecore:default"/>
-        <setEntry value="org.eclipse.emfcloud.ecore.codegen.feature:default"/>
         <setEntry value="org.eclipse.emfcloud.ecore.glsp.feature:default"/>
         <setEntry value="org.eclipse.emfcloud.ecore.modelserver.feature:default"/>
+        <setEntry value="org.eclipse.emfcloud.modelserver.feature:default"/>
         <setEntry value="org.eclipse.equinox.core.feature:default"/>
-        <setEntry value="org.eclipse.equinox.executable:default"/>
+        <setEntry value="org.eclipse.glsp.feature:default"/>
     </setAttribute>
     <setAttribute key="selected_target_bundles">
-        <setEntry value="ch.qos.logback.classic@default:default"/>
-        <setEntry value="ch.qos.logback.core@default:default"/>
-        <setEntry value="ch.qos.logback.slf4j@default:false"/>
-        <setEntry value="com.fasterxml.jackson.core.jackson-annotations@default:default"/>
-        <setEntry value="com.fasterxml.jackson.core.jackson-core@default:default"/>
-        <setEntry value="com.fasterxml.jackson.core.jackson-databind@default:default"/>
-        <setEntry value="com.google.gson*2.7.0.v20170129-0911@default:default"/>
-        <setEntry value="com.google.gson*2.8.2.v20180104-1110@default:default"/>
-        <setEntry value="com.google.guava@default:default"/>
-        <setEntry value="com.google.inject.multibindings@default:false"/>
-        <setEntry value="com.google.inject@default:default"/>
-        <setEntry value="com.ibm.icu@default:default"/>
-        <setEntry value="javax.inject@default:default"/>
-        <setEntry value="javax.websocket@default:default"/>
-        <setEntry value="net.bytebuddy.byte-buddy-agent@default:default"/>
-        <setEntry value="net.bytebuddy.byte-buddy@default:default"/>
-        <setEntry value="org.antlr.runtime@default:default"/>
-        <setEntry value="org.apache.ant@default:default"/>
-        <setEntry value="org.apache.commons.cli@default:default"/>
-        <setEntry value="org.apache.commons.io@default:default"/>
         <setEntry value="org.apache.felix.gogo.command@default:default"/>
         <setEntry value="org.apache.felix.gogo.runtime@default:default"/>
         <setEntry value="org.apache.felix.gogo.shell@default:default"/>
-        <setEntry value="org.apache.felix.scr@1:true"/>
-        <setEntry value="org.apache.log4j@default:default"/>
-        <setEntry value="org.eclipse.ant.core@default:default"/>
-        <setEntry value="org.eclipse.core.commands@default:default"/>
+        <setEntry value="org.apache.felix.scr@2:true"/>
         <setEntry value="org.eclipse.core.contenttype@default:default"/>
         <setEntry value="org.eclipse.core.expressions@default:default"/>
-        <setEntry value="org.eclipse.core.filesystem@default:default"/>
         <setEntry value="org.eclipse.core.jobs@default:default"/>
-        <setEntry value="org.eclipse.core.resources@default:default"/>
         <setEntry value="org.eclipse.core.runtime@default:true"/>
         <setEntry value="org.eclipse.core.variables@default:default"/>
-        <setEntry value="org.eclipse.debug.core@default:default"/>
-        <setEntry value="org.eclipse.elk.alg.common@default:default"/>
-        <setEntry value="org.eclipse.elk.alg.layered@default:default"/>
-        <setEntry value="org.eclipse.elk.core@default:default"/>
-        <setEntry value="org.eclipse.elk.graph.text@default:default"/>
-        <setEntry value="org.eclipse.elk.graph@default:default"/>
-        <setEntry value="org.eclipse.emf.ant@default:default"/>
-        <setEntry value="org.eclipse.emf.codegen.ecore@default:default"/>
-        <setEntry value="org.eclipse.emf.codegen@default:default"/>
-        <setEntry value="org.eclipse.emf.common@default:default"/>
-        <setEntry value="org.eclipse.emf.ecore.change@default:default"/>
-        <setEntry value="org.eclipse.emf.ecore.xmi@default:default"/>
-        <setEntry value="org.eclipse.emf.ecore@default:default"/>
-        <setEntry value="org.eclipse.emf.edit@default:default"/>
         <setEntry value="org.eclipse.emfcloud.modelserver.client@default:default"/>
         <setEntry value="org.eclipse.emfcloud.modelserver.common@default:default"/>
         <setEntry value="org.eclipse.emfcloud.modelserver.edit@default:default"/>
@@ -92,51 +57,28 @@
         <setEntry value="org.eclipse.equinox.app@default:default"/>
         <setEntry value="org.eclipse.equinox.common@2:true"/>
         <setEntry value="org.eclipse.equinox.console@default:default"/>
-        <setEntry value="org.eclipse.equinox.ds@1:true"/>
-        <setEntry value="org.eclipse.equinox.launcher.gtk.linux.x86_64@default:false"/>
-        <setEntry value="org.eclipse.equinox.launcher@default:default"/>
+        <setEntry value="org.eclipse.equinox.ds@2:true"/>
         <setEntry value="org.eclipse.equinox.preferences@default:default"/>
         <setEntry value="org.eclipse.equinox.registry@default:default"/>
         <setEntry value="org.eclipse.equinox.simpleconfigurator@1:true"/>
         <setEntry value="org.eclipse.glsp.graph@default:default"/>
-        <setEntry value="org.eclipse.glsp.layout@default:default"/>
         <setEntry value="org.eclipse.glsp.server@default:default"/>
-        <setEntry value="org.eclipse.jdt.core@default:default"/>
-        <setEntry value="org.eclipse.jdt.debug@default:default"/>
-        <setEntry value="org.eclipse.jdt.launching@default:default"/>
-        <setEntry value="org.eclipse.lsp4j.jsonrpc@default:default"/>
-        <setEntry value="org.eclipse.lsp4j@default:default"/>
-        <setEntry value="org.eclipse.osgi.compatibility.state@default:false"/>
+        <setEntry value="org.eclipse.osgi.compatibility.state@default:default"/>
         <setEntry value="org.eclipse.osgi.services@default:default"/>
         <setEntry value="org.eclipse.osgi.util@default:default"/>
-        <setEntry value="org.eclipse.osgi@-1:true"/>
-        <setEntry value="org.eclipse.text@default:default"/>
-        <setEntry value="org.eclipse.xtend.lib.macro@default:default"/>
-        <setEntry value="org.eclipse.xtend.lib@default:default"/>
-        <setEntry value="org.eclipse.xtext.util@default:default"/>
-        <setEntry value="org.eclipse.xtext.xbase.lib@default:default"/>
-        <setEntry value="org.eclipse.xtext@default:default"/>
-        <setEntry value="org.emfjson.jackson@default:default"/>
-        <setEntry value="org.hamcrest.core@default:default"/>
-        <setEntry value="org.hamcrest.integration@default:default"/>
-        <setEntry value="org.hamcrest.library@default:default"/>
-        <setEntry value="org.hamcrest.text@default:default"/>
-        <setEntry value="org.hamcrest@default:default"/>
-        <setEntry value="org.objenesis@default:default"/>
-        <setEntry value="org.slf4j.api@default:default"/>
+        <setEntry value="org.eclipse.osgi@default:true"/>
     </setAttribute>
     <setAttribute key="selected_workspace_bundles">
-        <setEntry value="org.eclipse.emfcloud.ecore.backend.app@default:default"/>
         <setEntry value="org.eclipse.emfcloud.ecore.glsp.app@default:default"/>
         <setEntry value="org.eclipse.emfcloud.ecore.glsp@default:default"/>
         <setEntry value="org.eclipse.emfcloud.ecore.modelserver.app@default:default"/>
         <setEntry value="org.eclipse.emfcloud.ecore.modelserver@default:default"/>
     </setAttribute>
     <booleanAttribute key="show_selected_only" value="false"/>
-    <stringAttribute key="templateConfig" value="${target_home}/configuration/config.ini"/>
     <booleanAttribute key="tracing" value="false"/>
-    <booleanAttribute key="useCustomFeatures" value="false"/>
+    <booleanAttribute key="useCustomFeatures" value="true"/>
     <booleanAttribute key="useDefaultConfig" value="true"/>
     <booleanAttribute key="useDefaultConfigArea" value="true"/>
     <booleanAttribute key="useProduct" value="true"/>
+    <booleanAttribute key="usefeatures" value="false"/>
 </launchConfiguration>

--- a/server/org.eclipse.emfcloud.ecore.modelserver/META-INF/MANIFEST.MF
+++ b/server/org.eclipse.emfcloud.ecore.modelserver/META-INF/MANIFEST.MF
@@ -6,7 +6,6 @@ Automatic-Module-Name: org.eclipse.emfcloud.ecore.modelserver
 Bundle-Version: 0.0.2.qualifier
 Bundle-ClassPath: .
 Bundle-Vendor: %providerName
-Bundle-Localization: plugin
 Bundle-RequiredExecutionEnvironment: JavaSE-11
 Require-Bundle: 
  org.apache.log4j;bundle-version="[1.2.15,2.0.0)",

--- a/server/org.eclipse.emfcloud.ecore.modelserver/build.properties
+++ b/server/org.eclipse.emfcloud.ecore.modelserver/build.properties
@@ -1,4 +1,4 @@
 jars.compile.order = .
 source.. = src/main/
-bin.includes = META-INF/
+bin.includes = .,META-INF/
 output.. = target/classes/

--- a/server/targetplatform/ecore-dev.target
+++ b/server/targetplatform/ecore-dev.target
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="Ecore GLSP Dev" sequenceNumber="1606313659">
+<target name="Ecore GLSP Dev" sequenceNumber="1606377904">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.glsp.server" version="0.8.0.202010130847"/>
-      <unit id="org.eclipse.glsp.graph" version="0.8.0.202010130847"/>
+      <unit id="org.eclipse.glsp.feature.feature.group" version="0.8.0.202010130847"/>
       <unit id="org.eclipse.glsp.layout" version="0.8.0.202010130847"/>
       <repository location="https://download.eclipse.org/glsp/server/p2/nightly/0.8/0.8.0.202010130847/"/>
     </location>
@@ -34,11 +33,7 @@
       <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20200529191137/repository/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.emfcloud.modelserver.client" version="0.7.0.202011251312"/>
-      <unit id="org.eclipse.emfcloud.modelserver.common" version="0.7.0.202011251312"/>
-      <unit id="org.eclipse.emfcloud.modelserver.emf" version="0.7.0.202011251312"/>
-      <unit id="org.eclipse.emfcloud.modelserver.edit" version="0.7.0.202011251312"/>
-      <unit id="org.eclipse.emfcloud.modelserver.lib" version="0.7.0.202011251312"/>
+      <unit id="org.eclipse.emfcloud.modelserver.feature.feature.group" version="0.7.0.202011251312"/>
       <repository location="https://download.eclipse.org/emfcloud/modelserver/p2/nightly/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">

--- a/server/targetplatform/ecore-server.target
+++ b/server/targetplatform/ecore-server.target
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <?pde?>
 <!-- generated with https://github.com/eclipse-cbi/targetplatform-dsl -->
-<target name="Ecore GLSP Server" sequenceNumber="1606313644">
+<target name="Ecore GLSP Server" sequenceNumber="1606318838">
   <locations>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.glsp.server" version="0.8.0.202010130847"/>
-      <unit id="org.eclipse.glsp.graph" version="0.8.0.202010130847"/>
+      <unit id="org.eclipse.glsp.feature.feature.group" version="0.8.0.202010130847"/>
       <unit id="org.eclipse.glsp.layout" version="0.8.0.202010130847"/>
       <repository location="https://download.eclipse.org/glsp/server/p2/nightly/0.8/0.8.0.202010130847/"/>
     </location>
@@ -40,11 +39,7 @@
       <repository location="https://download.eclipse.org/tools/orbit/downloads/drops/R20200529191137/repository/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">
-      <unit id="org.eclipse.emfcloud.modelserver.client" version="0.7.0.202011251312"/>
-      <unit id="org.eclipse.emfcloud.modelserver.common" version="0.7.0.202011251312"/>
-      <unit id="org.eclipse.emfcloud.modelserver.emf" version="0.7.0.202011251312"/>
-      <unit id="org.eclipse.emfcloud.modelserver.edit" version="0.7.0.202011251312"/>
-      <unit id="org.eclipse.emfcloud.modelserver.lib" version="0.7.0.202011251312"/>
+      <unit id="org.eclipse.emfcloud.modelserver.feature.feature.group" version="0.7.0.202011251312"/>
       <repository location="https://download.eclipse.org/emfcloud/modelserver/p2/nightly/"/>
     </location>
     <location includeMode="planner" includeAllPlatforms="false" includeSource="true" includeConfigurePhase="false" type="InstallableUnit">

--- a/server/targetplatform/ecore-server.tpd
+++ b/server/targetplatform/ecore-server.tpd
@@ -3,8 +3,7 @@ target "Ecore GLSP Server" with requirements, source
 // Target platform for the Ecore-GLSP Server (GLSP, ELK)
 
 location "https://download.eclipse.org/glsp/server/p2/nightly/0.8/0.8.0.202010130847/" {
-	org.eclipse.glsp.server [0.8.0,0.9.0)
-	org.eclipse.glsp.graph [0.8.0,0.9.0)
+	org.eclipse.glsp.feature.feature.group [0.8.0,0.9.0)
 	org.eclipse.glsp.layout [0.8.0,0.9.0)
 }
 
@@ -41,11 +40,7 @@ location "https://download.eclipse.org/tools/orbit/downloads/drops/R202005291911
 }
 
 location "https://download.eclipse.org/emfcloud/modelserver/p2/nightly/" {
-	org.eclipse.emfcloud.modelserver.client [0.7.0,0.8.0)
-	org.eclipse.emfcloud.modelserver.common [0.7.0,0.8.0)
-	org.eclipse.emfcloud.modelserver.emf [0.7.0,0.8.0)
-	org.eclipse.emfcloud.modelserver.edit [0.7.0,0.8.0)
-	org.eclipse.emfcloud.modelserver.lib [0.7.0,0.8.0)
+	org.eclipse.emfcloud.modelserver.feature.feature.group [0.7.0,0.8.0)
 }
 
 location "http://ghillairet.github.io/p2" {


### PR DESCRIPTION
When running from the Product, it was overriding the launch configuration with invalid contents. Now, the Launch Config has been updated to use Features (rather than Plug-ins), and is now consistent with what the  Product expects/overwrites.

Moreover, the plug-in metadata for org.eclipse.emfcloud.ecore.modelserver were incorrect: the plug-in could build correctly, but didn't include any *.class files once deployed as a jar/plug-in (Which is why the Tycho-built product didn't work).

I've also updated the Target Platform to use Features when they are available.

Now, both the Eclipse PDE Product and Tycho-built Product should work (i.e. start correctly)